### PR TITLE
Avoid ignoring "endOfConversation" items in the transcript.

### DIFF
--- a/transcript.js
+++ b/transcript.js
@@ -2,7 +2,10 @@ var _ = require("underscore");
 
 class Transcript {
     static getMessages(transcript) {
-        var messages = (transcript && _.isArray(transcript)) ? _.where(transcript, { type: "message" }) : [];
+        var messages = (transcript && _.isArray(transcript)) ? _.filter(transcript, function (obj) {
+                return obj.type === "message" || obj.type === "endOfConversation";
+            }
+        ) : [];
         messages = _.map(messages, 
                          function(message) {
                              return _.pick(message, ["type", "text", "attachments", "speak", "locale", "textFormat", "from", "recipient"]);


### PR DESCRIPTION
Application will avoid ignoring "endOfConversation" items in the transcript.
This change solves a bug that happened when conversation ends with this item (e.g. when user types "forget me" or "cancel").