### PR TITLE
Add new Handlers for camelCase and types issues

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -634,9 +634,9 @@
       }
     },
     "minimist": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
       "optional": true
     },
     "mixme": {
@@ -645,12 +645,12 @@
       "integrity": "sha512-tilCZOvIhRETXJuTmxxpz8mgplF7gmFhcH05JuR/YL+JLO98gLRQ1Mk4XpYQxxbPMKupSOv+Bidw7EKv8wds1w=="
     },
     "mkdirp": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+      "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
       "optional": true,
       "requires": {
-        "minimist": "0.0.8"
+        "minimist": "^1.2.5"
       }
     },
     "moment": {

--- a/transcriptTransformationScript.js
+++ b/transcriptTransformationScript.js
@@ -83,22 +83,13 @@ function convertColumnAttributesToCamelCase(currEntry) {
                                     columns.forEach(column => {
                                         if (column.hasOwnProperty("items")) {
                                             const colItems = column["items"];
+                                            const attributesToEdit = ["size", "weight", "color", "horizontalAlignment", "spacing"];
                                             colItems.forEach(colItem => {
-                                                if (colItem.hasOwnProperty("size")) {
-                                                    colItem["size"] = colItem["size"].charAt(0).toLowerCase() + colItem["size"].slice(1, colItem["size"].length);
-                                                }
-                                                if (colItem.hasOwnProperty("weight")) {
-                                                    colItem["weight"] = colItem["weight"].charAt(0).toLowerCase() + colItem["weight"].slice(1, colItem["weight"].length);
-                                                }
-                                                if (colItem.hasOwnProperty("color")) {
-                                                    colItem["color"] = colItem["color"].charAt(0).toLowerCase() + colItem["color"].slice(1, colItem["color"].length);
-                                                }
-                                                if (colItem.hasOwnProperty("horizontalAlignment")) {
-                                                    colItem["horizontalAlignment"] = colItem["horizontalAlignment"].charAt(0).toLowerCase() + colItem["horizontalAlignment"].slice(1, colItem["horizontalAlignment"].length);
-                                                }
-                                                if (colItem.hasOwnProperty("spacing")) {
-                                                    colItem["spacing"] = colItem["spacing"].charAt(0).toLowerCase() + colItem["spacing"].slice(1, colItem["spacing"].length);
-                                                }
+                                                attributesToEdit.forEach(attr => {
+                                                    if (colItem.hasOwnProperty(attr)) {
+                                                        colItem[attr] = colItem[attr].charAt(0).toLowerCase() + colItem[attr].slice(1, colItem[attr].length);
+                                                    }
+                                                });
                                             });
                                         }
                                     });

--- a/transcriptTransformationScript.js
+++ b/transcriptTransformationScript.js
@@ -75,34 +75,36 @@ function convertColumnAttributesToCamelCase(currEntry) {
                     const content = attachment["content"];
                     if (content.hasOwnProperty("body")) {
                         const contentBody = content["body"][0];
-                        const bodyItems = contentBody["items"];
-                        bodyItems.forEach(bodyItem => {
-                            if (bodyItem.hasOwnProperty("columns")) {
-                                const columns = bodyItem["columns"];
-                                columns.forEach(column => {
-                                    if (column.hasOwnProperty("items")) {
-                                        const colItems = column["items"];
-                                        colItems.forEach(colItem => {
-                                            if (colItem.hasOwnProperty("size")) {
-                                                colItem["size"] = colItem["size"].charAt(0).toLowerCase() + colItem["size"].slice(1, colItem["size"].length);
-                                            }
-                                            if (colItem.hasOwnProperty("weight")) {
-                                                colItem["weight"] = colItem["weight"].charAt(0).toLowerCase() + colItem["weight"].slice(1, colItem["weight"].length);
-                                            }
-                                            if (colItem.hasOwnProperty("color")) {
-                                                colItem["color"] = colItem["color"].charAt(0).toLowerCase() + colItem["color"].slice(1, colItem["color"].length);
-                                            }
-                                            if (colItem.hasOwnProperty("horizontalAlignment")) {
-                                                colItem["horizontalAlignment"] = colItem["horizontalAlignment"].charAt(0).toLowerCase() + colItem["horizontalAlignment"].slice(1, colItem["horizontalAlignment"].length);
-                                            }
-                                            if (colItem.hasOwnProperty("spacing")) {
-                                                colItem["spacing"] = colItem["spacing"].charAt(0).toLowerCase() + colItem["spacing"].slice(1, colItem["spacing"].length);
-                                            }
-                                        });
-                                    }
-                                });
-                            }
-                        });
+                        if (contentBody.hasOwnProperty("items")) {
+                            const bodyItems = contentBody["items"];
+                            bodyItems.forEach(bodyItem => {
+                                if (bodyItem.hasOwnProperty("columns")) {
+                                    const columns = bodyItem["columns"];
+                                    columns.forEach(column => {
+                                        if (column.hasOwnProperty("items")) {
+                                            const colItems = column["items"];
+                                            colItems.forEach(colItem => {
+                                                if (colItem.hasOwnProperty("size")) {
+                                                    colItem["size"] = colItem["size"].charAt(0).toLowerCase() + colItem["size"].slice(1, colItem["size"].length);
+                                                }
+                                                if (colItem.hasOwnProperty("weight")) {
+                                                    colItem["weight"] = colItem["weight"].charAt(0).toLowerCase() + colItem["weight"].slice(1, colItem["weight"].length);
+                                                }
+                                                if (colItem.hasOwnProperty("color")) {
+                                                    colItem["color"] = colItem["color"].charAt(0).toLowerCase() + colItem["color"].slice(1, colItem["color"].length);
+                                                }
+                                                if (colItem.hasOwnProperty("horizontalAlignment")) {
+                                                    colItem["horizontalAlignment"] = colItem["horizontalAlignment"].charAt(0).toLowerCase() + colItem["horizontalAlignment"].slice(1, colItem["horizontalAlignment"].length);
+                                                }
+                                                if (colItem.hasOwnProperty("spacing")) {
+                                                    colItem["spacing"] = colItem["spacing"].charAt(0).toLowerCase() + colItem["spacing"].slice(1, colItem["spacing"].length);
+                                                }
+                                            });
+                                        }
+                                    });
+                                }
+                            });
+                        }
                     }
                 }
             });


### PR DESCRIPTION
 
⚫  The camelCase handler was set because there is a mismatch in some attributes' values between the generated transcript and the bot directline response such as: 
**### transcript values:**
                                           "horizontalAlignment": "Center",
                                           "spacing": "Medium",
                                           "size": "ExtraLarge",
                                           "weight": "Bolder",
                                           "color": "Light", 
**### bot directline response:**
                                           "size": "extraLarge",
                                           "weight": "bolder",
                                           "color": "light",
                                           "horizontalAlignment": "center",
                                           "spacing": "medium"

⚫ The convertNumbersToString was set to simulate comparing attributes with ignoreCase
**### transcript values:**
                                            "width": 20,
                                            "width": 80,
**### bot directline response:**    
                                            "width": "20",
                                            "width": "80",
